### PR TITLE
Added extra space to ensure dispatch runs

### DIFF
--- a/autoload/easygit.vim
+++ b/autoload/easygit.vim
@@ -747,7 +747,7 @@ function! easygit#dispatch(name, args)
   if !has('gui_running')
     let pre = exists(':Nrun') ? 'Nrun ' : '!'
     if has('nvim') && pre ==# '!'
-      let pre = ':terminal'
+      let pre = ':terminal '
     endif
     exe 'lcd ' . root
     exe pre . cmd


### PR DESCRIPTION
I am using neovim, and when I run :Gpush, it reverts to ":terminalgit push". So I added a space to make it ":terminal git push"